### PR TITLE
feat(analytics): tag PostHog events with service

### DIFF
--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -23,6 +23,7 @@ export default {
           person_profiles: 'identified_only',
           capture_exceptions: true,
         });
+        posthog.register({ service: 'recordings-listing' });
       }
 
       const initSearchAnalytics = () => {


### PR DESCRIPTION
Registers `service: 'recordings-listing'` as a posthog-js super-property after init in the VitePress theme, so every event (incl. manual `\` and custom search/click events) is attributed to this app.